### PR TITLE
feat(api): implement S2-001 trip domain modules

### DIFF
--- a/TNS/Codex-TNS.md
+++ b/TNS/Codex-TNS.md
@@ -1,6 +1,7 @@
 # Codex.md — SaaS de Planejamento de Rota (Tracking + Detecção de Desvio)
 
 Este repositório é um monorepo para um SaaS de **gestão de frota em tempo real**, com:
+
 - tracking por GPS (pings),
 - comparação **rota planejada vs rota executada**,
 - métricas (km percorridos, km restantes, ETA aproximado),
@@ -16,29 +17,34 @@ Evolução planejada: **navegação embutida (Opção 2)** com SDK (Mapbox Navig
 ## 1) Premissas (não-negociáveis do MVP)
 
 ### Tracking
+
 - O motorista **não precisa** de navegação dentro do app no MVP.
 - O app do motorista (ou integração com rastreador) envia **pings** com:
   - `timestamp`, `lat`, `lng`, `accuracy_m`, `speed_mps`, `heading_deg` (quando disponível), `device_id`, `driver_id`, `vehicle_id`, `trip_id`.
 - O sistema mantém um “estado quente” do veículo (última posição + status) e um histórico (para auditoria/relatórios).
 
 ### Tiers de Ping e Detecção
+
 A detecção usa “corredor” (buffer) + confirmação para reduzir falso positivo.
 
-| Tier | Ping | Corredor (fora da rota) | Detecção típica | Uso |
-|---|---:|---:|---:|---|
-| Gold | 1s | 10m | 2–5s | compliance/segurança/auditoria pesada |
-| Silver | 15s | 30m | 30–60s | operação urbana padrão |
-| Bronze | 30s | 100m | 60–180s | visibilidade macro e custo/bateria baixo |
+| Tier   | Ping | Corredor (fora da rota) | Detecção típica | Uso                                      |
+| ------ | ---: | ----------------------: | --------------: | ---------------------------------------- |
+| Gold   |   1s |                     10m |            2–5s | compliance/segurança/auditoria pesada    |
+| Silver |  15s |                     30m |          30–60s | operação urbana padrão                   |
+| Bronze |  30s |                    100m |         60–180s | visibilidade macro e custo/bateria baixo |
 
 **Confirmação (recomendado):**
+
 - Gold: fora >10m por **5 pings** OU **8s** contínuos.
 - Silver: fora >30m por **2 pings** OU **45s** contínuos.
 - Bronze: fora >100m por **2–3 pings** OU **120s** contínuos.
 
 **Filtro anti-ruído:**
+
 - Se `accuracy_m` estiver ruim (ex.: > 30–50m), **não** dispare alerta imediato; marque como “suspeita” e peça confirmação por janela.
 
 ### Desvio também por “detour” (tempo/distância)
+
 Além de “fora do corredor”, detectamos desvio por piora de tempo/distância para o próximo destino.
 
 - **Detour por tempo (threshold padrão):**
@@ -49,9 +55,11 @@ Além de “fora do corredor”, detectamos desvio por piora de tempo/distância
 No Bronze, aumente thresholds (ex.: 30% ou 12 min) para evitar ruído.
 
 ### Ping adaptativo (economia com “turbo” quando importa)
+
 Mesmo com Bronze default:
-- Normal: 30s / 100m  
-- Suspeita: 15s / 30m por 2–3 min  
+
+- Normal: 30s / 100m
+- Suspeita: 15s / 30m por 2–3 min
 - Confirmado: 1s / 10m por 60–120s (para coletar trilha de auditoria)
 
 ---
@@ -59,6 +67,7 @@ Mesmo com Bronze default:
 ## 2) Arquitetura (visão de serviços)
 
 ### Serviços
+
 - **API (REST)**: gestão (tenants, veículos, motoristas, viagens, paradas, rotas, relatórios)
 - **Ingest API**: endpoint leve e rápido para receber pings (alta taxa)
 - **Realtime Gateway (WS)**: atualizações em tempo real do dashboard
@@ -66,12 +75,14 @@ Mesmo com Bronze default:
 - **Scheduler**: tarefas recorrentes (health checks, reconciliação, agregações)
 
 ### Data Stores
+
 - **PostgreSQL + PostGIS**: entidades e geoespacial (rotas, paradas, geofences)
 - **Timeseries (TimescaleDB ou particionamento)**: tabela de posições (pings)
 - **Redis**: estado quente (última posição, viagens ativas), rate limit, filas (BullMQ)
 - **Object Storage (S3)**: exports, arquivos, snapshots
 
 ### Infra (AWS baseline)
+
 - ECS Fargate (API/Workers) ou EKS (se necessário)
 - RDS Postgres + ElastiCache Redis
 - SQS/SNS (alternativa ao Redis para filas/alertas)
@@ -82,21 +93,24 @@ Mesmo com Bronze default:
 ## 3) Fluxos principais (MVP)
 
 ### Fluxo A — Criar viagem com múltiplas paradas (roteirização)
-1) Usuário cria `Trip` com `Stops` (endereços/latlng).
-2) Sistema resolve geocoding (se necessário) e roda **otimização de ordem** (VRP/TSP).
-3) Sistema gera rota por **perna** (Stop i -> Stop i+1) com polyline + distância + duração estimada.
-4) App do motorista recebe lista de paradas e a “próxima perna”.
+
+1. Usuário cria `Trip` com `Stops` (endereços/latlng).
+2. Sistema resolve geocoding (se necessário) e roda **otimização de ordem** (VRP/TSP).
+3. Sistema gera rota por **perna** (Stop i -> Stop i+1) com polyline + distância + duração estimada.
+4. App do motorista recebe lista de paradas e a “próxima perna”.
 
 ### Fluxo B — Motorista navega (Opção 1) + tracking
-1) App abre deep link para Google Maps/Waze com destino = próxima parada.
-2) App envia pings conforme tier/ping adaptativo.
-3) Backend calcula:
+
+1. App abre deep link para Google Maps/Waze com destino = próxima parada.
+2. App envia pings conforme tier/ping adaptativo.
+3. Backend calcula:
    - posição projetada na polyline (progresso),
    - km percorridos/pendentes,
    - detecção de desvio (corredor + detour).
-4) Eventos são enviados ao dashboard via WS.
+4. Eventos são enviados ao dashboard via WS.
 
 ### Fluxo C — Alertas
+
 - Eventos de interesse:
   - `OFF_ROUTE_SUSPECTED`, `OFF_ROUTE_CONFIRMED`, `BACK_ON_ROUTE`
   - `DETOUR_TIME`, `DETOUR_DISTANCE`
@@ -143,20 +157,23 @@ route-saas/
 ## 5.1) Guardrails de Qualidade (regra de ferro)
 
 ### Regra 0 — Nada nasce sem teste
+
 - **100% das funcionalidades** devem vir acompanhadas de teste(s) automatizados.
 - PR sem teste = **PR reprovado** (sem exceção).
 - Correção de bug = **teste que reproduz o bug primeiro**, depois o fix.
 
 ### Regra 1 — Double-check obrigatório (duas camadas)
+
 - `CODEOWNERS` por áreas sensíveis (auth/ingest/infra) para chamar reviewer certo automaticamente.
 - PR template com checklist curta e auto-label por path.
 
 Cada entrega passa por dois filtros:
-1) **Determinístico**: lint + typecheck + testes + cobertura mínima + análise estática.
-2) **Revisor** (humano e/ou IA): checklist de arquitetura + segurança + multi-tenant + custos de API.
 
+1. **Determinístico**: lint + typecheck + testes + cobertura mínima + análise estática.
+2. **Revisor** (humano e/ou IA): checklist de arquitetura + segurança + multi-tenant + custos de API.
 
 ### Checklist de Review (mínimo)
+
 - O contrato/schemas foram atualizados e versionados?
 - Existe teste que falha sem a mudança e passa com a mudança?
 - Multi-tenant: `tenant_id` está sempre escopado?
@@ -165,13 +182,17 @@ Cada entrega passa por dois filtros:
 - Migrações estão presentes e reversíveis?
 
 ### Regra 2 — Planejamento mínimo antes de codar
+
 Antes de implementar uma feature:
+
 - Escrever o **contrato** (DTO/schema/evento) e o **happy path**.
 - Definir **casos de erro** + **observabilidade** (logs/métricas).
 - Criar tarefas pequenas (máx. 1–2h cada) para evitar PRs gigantes.
 
 ### Regra 3 — Gates no CI (branch protection)
+
 Obrigatório em `main` e `release/*`:
+
 - `pnpm lint` (ou equivalente)
 - `pnpm typecheck`
 - `pnpm test` (unit + integration essenciais)
@@ -180,37 +201,42 @@ Obrigatório em `main` e `release/*`:
   - **bloqueia só em High/Critical**; Medium/Low vira warning + issue
 
 ### Regra 4 — Observabilidade como parte do DoD
+
 - Toda rota crítica e job crítico tem:
   - logs JSON com `tenant_id`, `trip_id`, `vehicle_id`
   - métricas (latência, filas, taxa de alertas)
   - tracing (OpenTelemetry) onde fizer sentido
 
 ### Regra 5 — Custos de Map API sob controle
+
 - Chamadas caras (route/eta/matching) devem ser:
   - cacheadas quando possível,
   - feitas sob demanda (suspeita/intervalo),
   - com limites por tenant/plano.
 
-
 ### Linguagem/Stack
+
 - TypeScript em tudo (web/mobile/backend)
 - Backend: NestJS (API), Fastify (Ingest)
 - DB: Postgres + PostGIS; Redis; TimescaleDB opcional
 - Observabilidade: OpenTelemetry; logs JSON
 
 ### Provedor de Mapas (abstração obrigatória)
+
 Para evitar lock-in e controlar custos, o código usa uma interface única `MapProvider` com adaptadores:
+
 - `GoogleProvider`: Routes/Geocoding (quando escolhido)
 - `MapboxProvider`: Directions/Geocoding/Map Matching (alternativa recomendada)
-Isso garante que a troca de provedor não reescreva o produto.
-
+  Isso garante que a troca de provedor não reescreva o produto.
 
 ### Estilo e regras
+
 - DTOs validados (zod/class-validator) e contratos versionados.
 - Eventos versionados (ex.: `off_route.confirmed.v1`).
 - Sem lógica “mágica” no front: tudo que é regra de desvio vive no backend.
 
 ### Testes (obrigatórios) — pirâmide prática
+
 - **Unit (rápidos, muitos):**
   - geo utils (distância ponto→linha, projeção na polyline, km restante)
   - detecção (tiers, confirmação, filtro por accuracy, detour)
@@ -226,6 +252,7 @@ Isso garante que a troca de provedor não reescreva o produto.
   - schemas (OpenAPI/eventos) testados com snapshots/validação
 
 ### Segurança
+
 - Multi-tenant com RLS (Row Level Security) ou scoping estrito por `tenant_id`.
 - Auth: JWT (MVP) com RBAC; SSO futuro.
 - Rate limiting por tenant no ingest.
@@ -237,18 +264,22 @@ Isso garante que a troca de provedor não reescreva o produto.
 Objetivo: **bloquear só o que é perigoso** e automatizar o resto. Segurança aqui é “cinto de segurança”, não “freio de mão puxado”.
 
 ### Camada A — Automática no CI (sempre)
+
 - **SCA** (Dependências): vulnerabilidades em libs (ex.: npm audit / osv / snyk/dep scan).
 - **Secrets scan**: impede token/senha indo pro Git (ex.: gitleaks).
 - **SAST leve** (código): regras rápidas (ex.: Semgrep/CodeQL) focadas em auth, SQL injection, SSRF, RCE.
 - **Container scan**: imagem base e pacotes (ex.: Trivy) — rápido e objetivo.
 
 **Regra de bloqueio (para não travar dev):**
+
 - Falha o PR **apenas** em `Critical/High` confirmados.
 - `Medium/Low` vira **warning + issue automática** (não bloqueia).
 - Permitir **override com justificativa** via label (`security-override`) + criação automática de ticket e prazo.
 
 ### Camada B — Review de segurança (risk-based, 2 minutos)
+
 Nem todo PR merece paranoia. A revisão extra só é exigida quando mexer em:
+
 - autenticação/autorização (JWT, RBAC, SSO)
 - multi-tenant scoping/RLS
 - ingest público (endpoint de pings), rate limiting, webhooks
@@ -256,14 +287,17 @@ Nem todo PR merece paranoia. A revisão extra só é exigida quando mexer em:
 - queries SQL/ORM “raw”, serialização, upload/download
 
 **Como detectar sem burocracia:**
+
 - PR template com checkbox “toca área sensível?”
 - ou labels automáticas por path (`services/ingest`, `services/api/auth`, `packages/contracts`, `infra/`).
 
 Quando cair em área sensível, o PR precisa de:
+
 - 1 reviewer extra (não precisa ser “time de segurança”; pode ser **Security Champion da semana**)
 - checklist curta (abaixo)
 
 ### Checklist de segurança (curto e útil)
+
 - Entrada externa validada (DTO/schema) e limites (tamanho/rate)?
 - Autorização checada em todos os endpoints (tenant_id escopado)?
 - Dados sensíveis não aparecem em logs?
@@ -271,21 +305,24 @@ Quando cair em área sensível, o PR precisa de:
 - Dependências novas foram justificadas?
 
 ### Camada C — Threat model “lite” (só para features grandes)
+
 Para mudanças grandes (ex.: novo canal de integração, novo modo de auth), escrever 10 linhas em `docs/ADR/`:
+
 - superfície exposta
 - principais riscos
 - mitigação
 - como monitorar (métrica/alerta)
 
-
 ## 6) Contratos (eventos e entidades) — resumo
 
 ### Entidades principais
+
 - `Tenant`, `User`, `Vehicle`, `Driver`, `Device`
 - `Trip`, `Stop`, `Leg`, `RoutePlan`, `RouteTrack`
 - `PositionPing`, `AlertEvent`
 
 ### Evento (exemplo)
+
 ```json
 {
   "event": "off_route.confirmed.v1",
@@ -307,12 +344,14 @@ Para mudanças grandes (ex.: novo canal de integração, novo modo de auth), esc
 ## 7) Roadmap (TODO por fases)
 
 ### Fase 0 — Fundacional (1–2 semanas)
+
 - Monorepo + CI (lint/typecheck/test/build) + **branch protection** (gates obrigatórios)
 - Infra local (docker compose) + Postgres/PostGIS + Redis
 - Autenticação + multi-tenant base
 - CRUD: veículos, motoristas, dispositivos
 
 ### Fase 1 — MVP (Opção 1: deep link + tracking)
+
 - Implementar `MapProvider` + adaptadores (Mapbox padrão; Google opcional)
 - Criar Trip com múltiplas paradas (Stops)
 - Otimização de ordem (VRP/TSP) + geração de Legs + polylines
@@ -323,12 +362,14 @@ Para mudanças grandes (ex.: novo canal de integração, novo modo de auth), esc
 - Push de alertas (mínimo: WS + email)
 
 ### Fase 1.1 — “Bom o bastante” em produção
+
 - Ping adaptativo (Bronze -> Silver -> Gold em suspeita)
 - Detour (tempo/distância) sob demanda (sem explodir custo)
 - Reprocessamento de trilha e relatórios
 - Limites por plano (veículos, pings/min, alertas)
 
 ### Fase 2 — Opção 2 (navegação embutida)
+
 - SDK de navegação no app do motorista (**Mapbox Navigation SDK** ou Google Navigation)
 - Reroute controlado + melhor telemetria
 - Offline parcial (fila local de pings e sync)
@@ -339,6 +380,7 @@ Para mudanças grandes (ex.: novo canal de integração, novo modo de auth), esc
 ## 8) Definição de pronto (Definition of Done)
 
 Para uma feature ser considerada pronta:
+
 - **tem testes automatizados** cobrindo o comportamento (unit e/ou integration),
 - tem contratos (DTO/schema) e versionamento quando necessário,
 - tem teste unitário do core (geo/detecção),
@@ -351,10 +393,12 @@ Para uma feature ser considerada pronta:
 ## 9) Docker-first (local dev e caminho para escala)
 
 ### Princípio
+
 - Tudo roda via **Docker** localmente (ambiente previsível) e evolui para deploy escalável.
 - O host só precisa de: Docker + Node + pnpm (ou usar devcontainer).
 
 ### Containers mínimos (MVP)
+
 - `postgres-postgis` (RDS compatível)
 - `redis`
 - `api`
@@ -364,12 +408,14 @@ Para uma feature ser considerada pronta:
 - `web-dashboard` (opcional rodar fora do Docker no início)
 
 ### Comandos padrão
+
 - `docker compose up -d` (subir infra)
 - `pnpm install`
 - `pnpm -r test` (obrigatório antes de subir serviços)
 - `pnpm -r dev` (dev servers)
 
 ### Regras Docker
+
 - Imagens **multi-stage** (build separado de runtime)
 - Nada de segredo em imagem; usar env vars/secret manager
 - Healthchecks em todos os serviços
@@ -380,13 +426,14 @@ Para uma feature ser considerada pronta:
 ## 10) Regras para Codex/Agentes (como gerar código aqui dentro)
 
 Quando um agente for implementar algo:
-1) **Comece pelo contrato** (DTOs/schemas) em `packages/contracts`.
-2) Implemente **utils geoespaciais** em `packages/shared/geo` com testes.
-3) No backend, prefira:
+
+1. **Comece pelo contrato** (DTOs/schemas) em `packages/contracts`.
+2. Implemente **utils geoespaciais** em `packages/shared/geo` com testes.
+3. No backend, prefira:
    - handlers puros + services injetáveis
    - jobs assíncronos para tudo que não for resposta imediata do ingest
-4) Não “inventar” nomes: usar as entidades/paths definidos acima.
-5) Sempre incluir:
+4. Não “inventar” nomes: usar as entidades/paths definidos acima.
+5. Sempre incluir:
    - migrations (quando mexer em schema),
    - testes do core,
    - observabilidade (logs + métricas).
@@ -396,9 +443,16 @@ Quando um agente for implementar algo:
 ## 13) Sprint 2 — MVP Core (Trip/Stops/Rotas)
 
 ### Objetivo
+
 Fechar domínio de viagens/paradas/pernas e geração de rota para alimentar tracking.
 
+### Status de execução (atual)
+
+- [x] `S2-001` Criar módulos `Trip`, `Stop`, `Leg`, `RoutePlan`, `RouteTrack` no `services/api`.
+- [ ] `S2-002` em diante (pendente).
+
 ### Mudanças importantes em APIs/interfaces/tipos públicos (Sprint 2-4)
+
 1. `POST /api/v1/trips`
 2. `POST /api/v1/trips/:tripId/stops/optimize`
 3. `GET /api/v1/trips/:tripId`
@@ -412,30 +466,31 @@ Fechar domínio de viagens/paradas/pernas e geração de rota para alimentar tra
 
 ### Backlog granular (Sprint 2)
 
-| ID | Tarefa | Estimativa | Dependência | Critério de aceite |
-|---|---|---:|---|---|
-| S2-001 | Criar módulos `Trip`, `Stop`, `Leg`, `RoutePlan`, `RouteTrack` no `services/api` | 2h | Sprint 1 API base | módulos compilam e sobem |
-| S2-002 | Expandir schema Prisma com entidades de viagem | 2h | S2-001 | migração gerada sem erro |
-| S2-003 | Criar migrations SQL para índices geoespaciais essenciais | 1.5h | S2-002 | índices aplicados |
-| S2-004 | Criar seed de dados para trips/stops demo | 1h | S2-002 | seed reproduzível |
-| S2-005 | Definir `TripDTO/StopDTO/LegDTO` em `packages/contracts` | 1.5h | S2-001 | schemas versionados |
-| S2-006 | Testes de contrato para DTOs de viagem | 1h | S2-005 | snapshots estáveis |
-| S2-007 | Implementar `POST /api/v1/trips` | 1.5h | S2-002,S2-005 | cria trip com tenant scoping |
-| S2-008 | Implementar `GET /api/v1/trips/:tripId` | 1h | S2-007 | retorno consistente com contrato |
-| S2-009 | Implementar `POST /api/v1/trips/:tripId/stops/optimize` | 2h | S2-007 | retorna ordem otimizada |
-| S2-010 | Implementar geração de `Legs` com polyline e métricas | 2h | S2-009 | legs persistidas |
-| S2-011 | Criar `MapProvider` runtime selector (`mock`/`mapbox`) | 1.5h | Sprint 1 contratos | troca por env var |
-| S2-012 | Implementar `MapboxProvider` mínimo (directions/geocoding) | 2h | S2-011 | integração funcional |
-| S2-013 | Implementar fallback mock quando token ausente | 1h | S2-011 | dev local não bloqueia |
-| S2-014 | Endpoint `POST /api/v1/trips/:tripId/start` | 1h | S2-010 | status da trip muda para ativa |
-| S2-015 | Gerador de deep links (Google/Waze) para próxima parada | 1h | S2-010 | link válido por leg |
-| S2-016 | Persistir baseline de ETA/distância planejada por leg | 1h | S2-010 | dados base para detour |
-| S2-017 | Testes integração fluxo criar trip -> otimizar -> gerar legs | 2h | S2-007..S2-016 | fluxo e2e backend verde |
-| S2-018 | Logs estruturados de viagem (`tenant_id/trip_id`) | 0.5h | S2-007 | logs rastreáveis |
-| S2-019 | Métricas de latência endpoints de trips | 0.5h | S2-007 | métrica exportada |
-| S2-020 | Documentar API de trips no MD | 1h | S2-005..S2-014 | contratos e exemplos registrados |
+| ID     | Tarefa                                                                           | Estimativa | Dependência        | Critério de aceite               |
+| ------ | -------------------------------------------------------------------------------- | ---------: | ------------------ | -------------------------------- |
+| S2-001 | Criar módulos `Trip`, `Stop`, `Leg`, `RoutePlan`, `RouteTrack` no `services/api` |         2h | Sprint 1 API base  | módulos compilam e sobem         |
+| S2-002 | Expandir schema Prisma com entidades de viagem                                   |         2h | S2-001             | migração gerada sem erro         |
+| S2-003 | Criar migrations SQL para índices geoespaciais essenciais                        |       1.5h | S2-002             | índices aplicados                |
+| S2-004 | Criar seed de dados para trips/stops demo                                        |         1h | S2-002             | seed reproduzível                |
+| S2-005 | Definir `TripDTO/StopDTO/LegDTO` em `packages/contracts`                         |       1.5h | S2-001             | schemas versionados              |
+| S2-006 | Testes de contrato para DTOs de viagem                                           |         1h | S2-005             | snapshots estáveis               |
+| S2-007 | Implementar `POST /api/v1/trips`                                                 |       1.5h | S2-002,S2-005      | cria trip com tenant scoping     |
+| S2-008 | Implementar `GET /api/v1/trips/:tripId`                                          |         1h | S2-007             | retorno consistente com contrato |
+| S2-009 | Implementar `POST /api/v1/trips/:tripId/stops/optimize`                          |         2h | S2-007             | retorna ordem otimizada          |
+| S2-010 | Implementar geração de `Legs` com polyline e métricas                            |         2h | S2-009             | legs persistidas                 |
+| S2-011 | Criar `MapProvider` runtime selector (`mock`/`mapbox`)                           |       1.5h | Sprint 1 contratos | troca por env var                |
+| S2-012 | Implementar `MapboxProvider` mínimo (directions/geocoding)                       |         2h | S2-011             | integração funcional             |
+| S2-013 | Implementar fallback mock quando token ausente                                   |         1h | S2-011             | dev local não bloqueia           |
+| S2-014 | Endpoint `POST /api/v1/trips/:tripId/start`                                      |         1h | S2-010             | status da trip muda para ativa   |
+| S2-015 | Gerador de deep links (Google/Waze) para próxima parada                          |         1h | S2-010             | link válido por leg              |
+| S2-016 | Persistir baseline de ETA/distância planejada por leg                            |         1h | S2-010             | dados base para detour           |
+| S2-017 | Testes integração fluxo criar trip -> otimizar -> gerar legs                     |         2h | S2-007..S2-016     | fluxo e2e backend verde          |
+| S2-018 | Logs estruturados de viagem (`tenant_id/trip_id`)                                |       0.5h | S2-007             | logs rastreáveis                 |
+| S2-019 | Métricas de latência endpoints de trips                                          |       0.5h | S2-007             | métrica exportada                |
+| S2-020 | Documentar API de trips no MD                                                    |         1h | S2-005..S2-014     | contratos e exemplos registrados |
 
 ### Critério de conclusão da Sprint 2
+
 1. Trip com múltiplas paradas criada, otimizada e iniciada.
 2. Legs com polyline e baseline ETA/distância persistidas.
 3. Deep link da próxima parada disponível.
@@ -446,34 +501,36 @@ Fechar domínio de viagens/paradas/pernas e geração de rota para alimentar tra
 ## 14) Sprint 3 — Tracking + Alertas + Dashboard
 
 ### Objetivo
+
 Fechar fluxo de operação em tempo real (ingest -> detecção -> evento -> dashboard).
 
 ### Backlog granular (Sprint 3)
 
-| ID | Tarefa | Estimativa | Dependência | Critério de aceite |
-|---|---|---:|---|---|
-| S3-001 | Consolidar tiers Bronze/Silver/Gold em config versionada | 1h | Sprint 1 ingest | thresholds centralizados |
-| S3-002 | Implementar máquina de estado `normal/suspeita/confirmado` | 2h | S3-001 | transições testadas |
-| S3-003 | Filtro anti-ruído por `accuracy_m` | 1h | S3-002 | ruído não gera alerta imediato |
-| S3-004 | Cálculo real de progresso sobre polyline | 2h | Sprint 2 legs | progresso consistente |
-| S3-005 | Cálculo km percorrido/restante por trip ativa | 1h | S3-004 | valores no endpoint |
-| S3-006 | Cálculo ETA aproximado atualizado por ping | 1.5h | S3-004 | ETA disponível |
-| S3-007 | Finalizar `GET /api/v1/trips/:tripId/progress` | 1h | S3-004..S3-006 | resposta final contratada |
-| S3-008 | Emitir evento `off_route.suspected.v1` | 1h | S3-002 | evento versionado |
-| S3-009 | Emitir evento `off_route.confirmed.v1` | 1h | S3-002 | evento versionado |
-| S3-010 | Emitir evento `back_on_route.v1` | 1h | S3-002 | retorno de rota detectado |
-| S3-011 | Criar `GET /api/v1/alerts` com filtros | 1.5h | S3-008..S3-010 | lista de alertas funcional |
-| S3-012 | Publicar canais WS `trip.progress.v1` e `alert.event.v1` | 1.5h | S3-007..S3-010 | stream ativo |
-| S3-013 | Tela dashboard `trips` com status em tempo real | 2h | Sprint 1 web | lista ao vivo |
-| S3-014 | Tela detalhe da viagem com progresso e ETA | 2h | S3-007,S3-012 | detalhe funcional |
-| S3-015 | Tela `alerts` com filtros básicos | 1.5h | S3-011 | operação de alertas funcional |
-| S3-016 | Integrar mapa em tempo real no dashboard (Mapbox GL) | 2h | S3-013 | rota + posição atual |
-| S3-017 | Mecanismo mínimo de envio email para alertas confirmados | 1.5h | S3-009 | envio assíncrono funcionando |
-| S3-018 | Testes integração ingest -> worker -> ws -> dashboard payload | 2h | S3-012 | contrato ponta-a-ponta validado |
-| S3-019 | Testes unitários regras Bronze e confirmação temporal | 1.5h | S3-002 | regras sem regressão |
-| S3-020 | Documentar fluxo operacional em `Codex-TNS.md` | 1h | S3-001..S3-017 | guia atualizado |
+| ID     | Tarefa                                                        | Estimativa | Dependência     | Critério de aceite              |
+| ------ | ------------------------------------------------------------- | ---------: | --------------- | ------------------------------- |
+| S3-001 | Consolidar tiers Bronze/Silver/Gold em config versionada      |         1h | Sprint 1 ingest | thresholds centralizados        |
+| S3-002 | Implementar máquina de estado `normal/suspeita/confirmado`    |         2h | S3-001          | transições testadas             |
+| S3-003 | Filtro anti-ruído por `accuracy_m`                            |         1h | S3-002          | ruído não gera alerta imediato  |
+| S3-004 | Cálculo real de progresso sobre polyline                      |         2h | Sprint 2 legs   | progresso consistente           |
+| S3-005 | Cálculo km percorrido/restante por trip ativa                 |         1h | S3-004          | valores no endpoint             |
+| S3-006 | Cálculo ETA aproximado atualizado por ping                    |       1.5h | S3-004          | ETA disponível                  |
+| S3-007 | Finalizar `GET /api/v1/trips/:tripId/progress`                |         1h | S3-004..S3-006  | resposta final contratada       |
+| S3-008 | Emitir evento `off_route.suspected.v1`                        |         1h | S3-002          | evento versionado               |
+| S3-009 | Emitir evento `off_route.confirmed.v1`                        |         1h | S3-002          | evento versionado               |
+| S3-010 | Emitir evento `back_on_route.v1`                              |         1h | S3-002          | retorno de rota detectado       |
+| S3-011 | Criar `GET /api/v1/alerts` com filtros                        |       1.5h | S3-008..S3-010  | lista de alertas funcional      |
+| S3-012 | Publicar canais WS `trip.progress.v1` e `alert.event.v1`      |       1.5h | S3-007..S3-010  | stream ativo                    |
+| S3-013 | Tela dashboard `trips` com status em tempo real               |         2h | Sprint 1 web    | lista ao vivo                   |
+| S3-014 | Tela detalhe da viagem com progresso e ETA                    |         2h | S3-007,S3-012   | detalhe funcional               |
+| S3-015 | Tela `alerts` com filtros básicos                             |       1.5h | S3-011          | operação de alertas funcional   |
+| S3-016 | Integrar mapa em tempo real no dashboard (Mapbox GL)          |         2h | S3-013          | rota + posição atual            |
+| S3-017 | Mecanismo mínimo de envio email para alertas confirmados      |       1.5h | S3-009          | envio assíncrono funcionando    |
+| S3-018 | Testes integração ingest -> worker -> ws -> dashboard payload |         2h | S3-012          | contrato ponta-a-ponta validado |
+| S3-019 | Testes unitários regras Bronze e confirmação temporal         |       1.5h | S3-002          | regras sem regressão            |
+| S3-020 | Documentar fluxo operacional em `Codex-TNS.md`                |         1h | S3-001..S3-017  | guia atualizado                 |
 
 ### Critério de conclusão da Sprint 3
+
 1. Fluxo real-time completo disponível no dashboard.
 2. Alertas suspeito/confirmado/back-on-route emitidos e listáveis.
 3. Progresso, km e ETA disponíveis por trip.
@@ -484,38 +541,40 @@ Fechar fluxo de operação em tempo real (ingest -> detecção -> evento -> dash
 ## 15) Sprint 4 — Deploy Local RC + AWS Staging-Ready
 
 ### Objetivo
+
 Colocar o sistema em estado de release local confiável e com trilha pronta para staging AWS.
 
 ### Backlog granular (Sprint 4)
 
-| ID | Tarefa | Estimativa | Dependência | Critério de aceite |
-|---|---|---:|---|---|
-| S4-001 | Revisar Dockerfiles multi-stage de todos serviços | 1.5h | Sprints 1-3 | imagens estáveis |
-| S4-002 | Ajustar `compose.yml` com profiles (`core`, `full`) | 1h | S4-001 | subida por perfil |
-| S4-003 | Adicionar healthchecks finais (api/ingest/worker/ws/web/db/redis) | 1h | S4-002 | status saudável |
-| S4-004 | Padronizar variáveis de ambiente por serviço | 1h | S4-002 | `.env.example` completo |
-| S4-005 | Implementar readiness endpoint por serviço | 1h | S4-003 | readiness consultável |
-| S4-006 | Finalizar `GET /ops/release-status` (version, commit, env, health) | 1h | S4-005 | payload completo |
-| S4-007 | Finalizar tela `/deploy` consumindo release-status | 1h | S4-006 | tela operacional |
-| S4-008 | Incluir links de runbook/logs na `/deploy` | 0.5h | S4-007 | operação guiada |
-| S4-009 | Criar workflow CI `build-and-test` com matriz de serviços | 1.5h | Sprint 1 CI | pipeline consistente |
-| S4-010 | Criar workflow `docker-build` para imagens tagged por commit | 1.5h | S4-009 | artefatos versionados |
-| S4-011 | Configurar scan Trivy nas imagens geradas | 0.5h | S4-010 | relatório de segurança |
-| S4-012 | Configurar gates finais (lint/typecheck/test/security High/Critical) | 1h | S4-009..011 | política aplicada |
-| S4-013 | Criar pasta `infra/terraform/staging` (skeleton) | 1h | S4-004 | estrutura IaC pronta |
-| S4-014 | Definir módulos placeholders `network`, `data`, `services` | 1.5h | S4-013 | plano organizacional pronto |
-| S4-015 | Criar `tfvars.example` de staging | 0.5h | S4-013 | parâmetros documentados |
-| S4-016 | Mapear serviços Docker -> serviços ECS (documento de mapping) | 1h | S4-013 | trilha de migração clara |
-| S4-017 | Criar runbook `local-release.md` (subir, validar, rollback) | 1h | S4-002..S4-008 | operação reprodutível |
-| S4-018 | Criar runbook `staging-readiness.md` (checklist pré-AWS) | 1h | S4-013..S4-016 | checklist fechado |
-| S4-019 | Teste de carga leve no ingest (cenário bronze) | 1h | Sprints 2-3 | comportamento conhecido |
-| S4-020 | Teste de chaos básico (restart worker/realtime) | 1h | S4-003 | recuperação validada |
-| S4-021 | Auditoria final de multi-tenant em APIs críticas | 1h | Sprints 2-3 | sem vazamento entre tenants |
-| S4-022 | Congelar contratos v1 para release local | 0.5h | S3-020 | versão estável |
-| S4-023 | Checklist final Go/No-Go de deploy local | 0.5h | S4-001..S4-022 | release decisionável |
-| S4-024 | Registrar retro técnica e backlog pós-deploy | 0.5h | fim sprint | próximos passos definidos |
+| ID     | Tarefa                                                               | Estimativa | Dependência    | Critério de aceite          |
+| ------ | -------------------------------------------------------------------- | ---------: | -------------- | --------------------------- |
+| S4-001 | Revisar Dockerfiles multi-stage de todos serviços                    |       1.5h | Sprints 1-3    | imagens estáveis            |
+| S4-002 | Ajustar `compose.yml` com profiles (`core`, `full`)                  |         1h | S4-001         | subida por perfil           |
+| S4-003 | Adicionar healthchecks finais (api/ingest/worker/ws/web/db/redis)    |         1h | S4-002         | status saudável             |
+| S4-004 | Padronizar variáveis de ambiente por serviço                         |         1h | S4-002         | `.env.example` completo     |
+| S4-005 | Implementar readiness endpoint por serviço                           |         1h | S4-003         | readiness consultável       |
+| S4-006 | Finalizar `GET /ops/release-status` (version, commit, env, health)   |         1h | S4-005         | payload completo            |
+| S4-007 | Finalizar tela `/deploy` consumindo release-status                   |         1h | S4-006         | tela operacional            |
+| S4-008 | Incluir links de runbook/logs na `/deploy`                           |       0.5h | S4-007         | operação guiada             |
+| S4-009 | Criar workflow CI `build-and-test` com matriz de serviços            |       1.5h | Sprint 1 CI    | pipeline consistente        |
+| S4-010 | Criar workflow `docker-build` para imagens tagged por commit         |       1.5h | S4-009         | artefatos versionados       |
+| S4-011 | Configurar scan Trivy nas imagens geradas                            |       0.5h | S4-010         | relatório de segurança      |
+| S4-012 | Configurar gates finais (lint/typecheck/test/security High/Critical) |         1h | S4-009..011    | política aplicada           |
+| S4-013 | Criar pasta `infra/terraform/staging` (skeleton)                     |         1h | S4-004         | estrutura IaC pronta        |
+| S4-014 | Definir módulos placeholders `network`, `data`, `services`           |       1.5h | S4-013         | plano organizacional pronto |
+| S4-015 | Criar `tfvars.example` de staging                                    |       0.5h | S4-013         | parâmetros documentados     |
+| S4-016 | Mapear serviços Docker -> serviços ECS (documento de mapping)        |         1h | S4-013         | trilha de migração clara    |
+| S4-017 | Criar runbook `local-release.md` (subir, validar, rollback)          |         1h | S4-002..S4-008 | operação reprodutível       |
+| S4-018 | Criar runbook `staging-readiness.md` (checklist pré-AWS)             |         1h | S4-013..S4-016 | checklist fechado           |
+| S4-019 | Teste de carga leve no ingest (cenário bronze)                       |         1h | Sprints 2-3    | comportamento conhecido     |
+| S4-020 | Teste de chaos básico (restart worker/realtime)                      |         1h | S4-003         | recuperação validada        |
+| S4-021 | Auditoria final de multi-tenant em APIs críticas                     |         1h | Sprints 2-3    | sem vazamento entre tenants |
+| S4-022 | Congelar contratos v1 para release local                             |       0.5h | S3-020         | versão estável              |
+| S4-023 | Checklist final Go/No-Go de deploy local                             |       0.5h | S4-001..S4-022 | release decisionável        |
+| S4-024 | Registrar retro técnica e backlog pós-deploy                         |       0.5h | fim sprint     | próximos passos definidos   |
 
 ### Critério de conclusão da Sprint 4
+
 1. `docker compose --profile full up -d` sobe stack completa sem erro crítico.
 2. Tela `/deploy` mostra estado operacional real.
 3. Pipelines de CI e build de imagem estáveis.
@@ -538,6 +597,7 @@ Colocar o sistema em estado de release local confiável e com trilha pronta para
 ## 17) Riscos, Mitigações e Itens Pós-Deploy
 
 ### Riscos principais
+
 1. Custo e latência de chamadas de mapas acima do previsto.
 2. Falso positivo em detecção de desvio por ruído de GPS.
 3. Gargalo no ingest/worker com aumento de pings.
@@ -545,6 +605,7 @@ Colocar o sistema em estado de release local confiável e com trilha pronta para
 5. Instabilidade de serviços em reinício local.
 
 ### Mitigações
+
 1. `MapProvider` com modo `mock`/`mapbox`, cache e fallback para reduzir custo.
 2. Filtro por `accuracy_m` + confirmação por janela antes de alerta confirmado.
 3. Rate limit por tenant + fila assíncrona + testes de carga leve por sprint.
@@ -552,6 +613,7 @@ Colocar o sistema em estado de release local confiável e com trilha pronta para
 5. Healthchecks + runbook de rollback + teste de chaos básico.
 
 ### Itens pós-deploy local (próxima etapa)
+
 1. Aplicar Terraform de staging AWS (`network/data/services`) com segredos gerenciados.
 2. Publicar imagens em registry e amarrar pipeline de promoção para staging.
 3. Implementar detour (tempo/distância) em produção com controle de custo.

--- a/TNS/services/api/src/main.ts
+++ b/TNS/services/api/src/main.ts
@@ -1,8 +1,21 @@
 import { createServer } from "node:http";
+import { createDomainModules } from "./modules/index.js";
 
 const port = Number(process.env.API_PORT ?? 3000);
+const domainModules = createDomainModules();
 
 const server = createServer((req, res) => {
+  if (req.url === "/ops/domain-modules") {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(
+      JSON.stringify({
+        status: "ok",
+        modules: Object.keys(domainModules),
+      }),
+    );
+    return;
+  }
+
   if (req.url === "/health") {
     res.writeHead(200, { "content-type": "application/json" });
     res.end(JSON.stringify({ status: "ok", service: "api" }));

--- a/TNS/services/api/src/modules/domain.types.ts
+++ b/TNS/services/api/src/modules/domain.types.ts
@@ -1,0 +1,49 @@
+export const tripStatuses = ["draft", "planned", "active", "completed", "canceled"] as const;
+
+export type TripStatus = (typeof tripStatuses)[number];
+
+export type LatLngDTO = {
+  lat: number;
+  lng: number;
+};
+
+export type StopDTO = {
+  id: string;
+  order: number;
+  name: string;
+  address: string;
+  location: LatLngDTO;
+};
+
+export type LegDTO = {
+  id: string;
+  from_stop_id: string;
+  to_stop_id: string;
+  polyline: string;
+  distance_m: number;
+  duration_s: number;
+};
+
+export type RoutePlanDTO = {
+  legs: LegDTO[];
+  total_distance_m: number;
+  total_duration_s: number;
+};
+
+export type RouteTrackDTO = {
+  progress_pct: number;
+  distance_done_m: number;
+  distance_remaining_m: number;
+  eta_s: number | null;
+};
+
+export type TripDTO = {
+  id: string;
+  tenant_id: string;
+  vehicle_id: string;
+  driver_id: string;
+  status: TripStatus;
+  stops: StopDTO[];
+  route_plan?: RoutePlanDTO;
+  route_track?: RouteTrackDTO;
+};

--- a/TNS/services/api/src/modules/index.ts
+++ b/TNS/services/api/src/modules/index.ts
@@ -1,0 +1,30 @@
+import { LegModule } from "./leg/leg.module.js";
+import { RoutePlanModule } from "./route-plan/route-plan.module.js";
+import { RouteTrackModule } from "./route-track/route-track.module.js";
+import { StopModule } from "./stop/stop.module.js";
+import { TripModule } from "./trip/trip.module.js";
+
+export function createDomainModules() {
+  const stop = new StopModule();
+  const leg = new LegModule();
+  const routePlan = new RoutePlanModule();
+  const routeTrack = new RouteTrackModule();
+  const trip = new TripModule(stop, routePlan, routeTrack);
+
+  return {
+    trip,
+    stop,
+    leg,
+    routePlan,
+    routeTrack,
+  };
+}
+
+export type DomainModules = ReturnType<typeof createDomainModules>;
+
+export { LegModule } from "./leg/leg.module.js";
+export { RoutePlanModule } from "./route-plan/route-plan.module.js";
+export { RouteTrackModule } from "./route-track/route-track.module.js";
+export { StopModule } from "./stop/stop.module.js";
+export { TripModule } from "./trip/trip.module.js";
+export * from "./domain.types.js";

--- a/TNS/services/api/src/modules/leg/leg.module.ts
+++ b/TNS/services/api/src/modules/leg/leg.module.ts
@@ -1,0 +1,39 @@
+import type { LegDTO, StopDTO } from "../domain.types.js";
+
+type CreateLegInput = {
+  id: string;
+  from: StopDTO;
+  to: StopDTO;
+  polyline: string;
+  distance_m: number;
+  duration_s: number;
+};
+
+export class LegModule {
+  create(input: LegDTO): LegDTO {
+    if (!input.id || !input.from_stop_id || !input.to_stop_id || !input.polyline) {
+      throw new TypeError("Leg invalido: campos obrigatorios ausentes.");
+    }
+
+    if (!Number.isFinite(input.distance_m) || input.distance_m < 0) {
+      throw new TypeError("Leg invalido: distance_m deve ser numero >= 0.");
+    }
+
+    if (!Number.isFinite(input.duration_s) || input.duration_s < 0) {
+      throw new TypeError("Leg invalido: duration_s deve ser numero >= 0.");
+    }
+
+    return { ...input };
+  }
+
+  fromStops(input: CreateLegInput): LegDTO {
+    return this.create({
+      id: input.id,
+      from_stop_id: input.from.id,
+      to_stop_id: input.to.id,
+      polyline: input.polyline,
+      distance_m: input.distance_m,
+      duration_s: input.duration_s,
+    });
+  }
+}

--- a/TNS/services/api/src/modules/route-plan/route-plan.module.ts
+++ b/TNS/services/api/src/modules/route-plan/route-plan.module.ts
@@ -1,0 +1,33 @@
+import type { LegDTO, RoutePlanDTO } from "../domain.types.js";
+
+export class RoutePlanModule {
+  create(input: RoutePlanDTO): RoutePlanDTO {
+    if (!Array.isArray(input.legs)) {
+      throw new TypeError("RoutePlan invalido: legs deve ser array.");
+    }
+
+    if (!Number.isFinite(input.total_distance_m) || input.total_distance_m < 0) {
+      throw new TypeError("RoutePlan invalido: total_distance_m deve ser numero >= 0.");
+    }
+
+    if (!Number.isFinite(input.total_duration_s) || input.total_duration_s < 0) {
+      throw new TypeError("RoutePlan invalido: total_duration_s deve ser numero >= 0.");
+    }
+
+    return {
+      ...input,
+      legs: input.legs.map((leg) => ({ ...leg })),
+    };
+  }
+
+  build(legs: LegDTO[]): RoutePlanDTO {
+    const total_distance_m = legs.reduce((sum, leg) => sum + leg.distance_m, 0);
+    const total_duration_s = legs.reduce((sum, leg) => sum + leg.duration_s, 0);
+
+    return this.create({
+      legs,
+      total_distance_m,
+      total_duration_s,
+    });
+  }
+}

--- a/TNS/services/api/src/modules/route-track/route-track.module.ts
+++ b/TNS/services/api/src/modules/route-track/route-track.module.ts
@@ -1,0 +1,45 @@
+import type { RouteTrackDTO } from "../domain.types.js";
+
+export class RouteTrackModule {
+  create(input: RouteTrackDTO): RouteTrackDTO {
+    if (
+      !Number.isFinite(input.progress_pct) ||
+      input.progress_pct < 0 ||
+      input.progress_pct > 100
+    ) {
+      throw new TypeError("RouteTrack invalido: progress_pct deve estar entre 0 e 100.");
+    }
+
+    if (!Number.isFinite(input.distance_done_m) || input.distance_done_m < 0) {
+      throw new TypeError("RouteTrack invalido: distance_done_m deve ser numero >= 0.");
+    }
+
+    if (!Number.isFinite(input.distance_remaining_m) || input.distance_remaining_m < 0) {
+      throw new TypeError("RouteTrack invalido: distance_remaining_m deve ser numero >= 0.");
+    }
+
+    if (input.eta_s !== null && (!Number.isFinite(input.eta_s) || input.eta_s < 0)) {
+      throw new TypeError("RouteTrack invalido: eta_s deve ser null ou numero >= 0.");
+    }
+
+    return { ...input };
+  }
+
+  fromDistance(
+    distance_done_m: number,
+    total_distance_m: number,
+    eta_s: number | null,
+  ): RouteTrackDTO {
+    const safeTotal = total_distance_m <= 0 ? 0 : total_distance_m;
+    const boundedDone = Math.max(0, Math.min(distance_done_m, safeTotal || distance_done_m));
+    const distance_remaining_m = Math.max(0, safeTotal - boundedDone);
+    const progress_pct = safeTotal === 0 ? 0 : (boundedDone / safeTotal) * 100;
+
+    return this.create({
+      progress_pct,
+      distance_done_m: boundedDone,
+      distance_remaining_m,
+      eta_s,
+    });
+  }
+}

--- a/TNS/services/api/src/modules/stop/stop.module.ts
+++ b/TNS/services/api/src/modules/stop/stop.module.ts
@@ -1,0 +1,28 @@
+import type { StopDTO } from "../domain.types.js";
+
+export class StopModule {
+  create(input: StopDTO): StopDTO {
+    if (!input.id || !input.name || !input.address) {
+      throw new TypeError("Stop invalido: campos de texto obrigatorios ausentes.");
+    }
+
+    if (!Number.isInteger(input.order) || input.order < 0) {
+      throw new TypeError("Stop invalido: order deve ser inteiro >= 0.");
+    }
+
+    if (!Number.isFinite(input.location.lat) || !Number.isFinite(input.location.lng)) {
+      throw new TypeError("Stop invalido: location.lat/lng devem ser numericos.");
+    }
+
+    return { ...input };
+  }
+
+  normalize(stops: StopDTO[]): StopDTO[] {
+    return [...stops]
+      .sort((a, b) => a.order - b.order)
+      .map((stop, index) => ({
+        ...stop,
+        order: index,
+      }));
+  }
+}

--- a/TNS/services/api/src/modules/trip/trip.module.ts
+++ b/TNS/services/api/src/modules/trip/trip.module.ts
@@ -1,0 +1,57 @@
+import { type LegDTO, type TripStatus, type TripDTO, tripStatuses } from "../domain.types.js";
+import { RoutePlanModule } from "../route-plan/route-plan.module.js";
+import { RouteTrackModule } from "../route-track/route-track.module.js";
+import { StopModule } from "../stop/stop.module.js";
+
+export class TripModule {
+  constructor(
+    private readonly stopModule = new StopModule(),
+    private readonly routePlanModule = new RoutePlanModule(),
+    private readonly routeTrackModule = new RouteTrackModule(),
+  ) {}
+
+  create(input: TripDTO): TripDTO {
+    if (!input.id || !input.tenant_id || !input.vehicle_id || !input.driver_id) {
+      throw new TypeError("Trip invalida: campos de identificacao obrigatorios ausentes.");
+    }
+
+    if (!this.isTripStatus(input.status)) {
+      throw new TypeError("Trip invalida: status fora do dominio esperado.");
+    }
+
+    if (input.stops.length < 2) {
+      throw new TypeError("Trip invalida: minimo de 2 stops.");
+    }
+
+    const normalizedStops = this.stopModule.normalize(
+      input.stops.map((stop) => this.stopModule.create(stop)),
+    );
+
+    return {
+      ...input,
+      stops: normalizedStops,
+    };
+  }
+
+  attachRoutePlan(trip: TripDTO, legs: LegDTO[]): TripDTO {
+    const route_plan = this.routePlanModule.build(legs);
+    return this.create({
+      ...trip,
+      route_plan,
+    });
+  }
+
+  updateRouteTrack(trip: TripDTO, distance_done_m: number, eta_s: number | null): TripDTO {
+    const plannedDistance = trip.route_plan?.total_distance_m ?? 0;
+    const route_track = this.routeTrackModule.fromDistance(distance_done_m, plannedDistance, eta_s);
+
+    return this.create({
+      ...trip,
+      route_track,
+    });
+  }
+
+  private isTripStatus(status: string): status is TripStatus {
+    return tripStatuses.includes(status as TripStatus);
+  }
+}

--- a/TNS/tests/integration/api-domain-modules.integration.test.ts
+++ b/TNS/tests/integration/api-domain-modules.integration.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createDomainModules } from "../../services/api/src/modules/index.js";
+
+test("fluxo de dominio: create trip -> plan legs -> update route_track", () => {
+  const modules = createDomainModules();
+
+  const baseTrip = modules.trip.create({
+    id: "trip_flow_1",
+    tenant_id: "tenant_1",
+    vehicle_id: "vehicle_1",
+    driver_id: "driver_1",
+    status: "planned",
+    stops: [
+      {
+        id: "stop_1",
+        order: 0,
+        name: "Ponto A",
+        address: "A",
+        location: { lat: -23.55, lng: -46.63 },
+      },
+      {
+        id: "stop_2",
+        order: 1,
+        name: "Ponto B",
+        address: "B",
+        location: { lat: -23.56, lng: -46.64 },
+      },
+      {
+        id: "stop_3",
+        order: 2,
+        name: "Ponto C",
+        address: "C",
+        location: { lat: -23.57, lng: -46.65 },
+      },
+    ],
+  });
+
+  const legA = modules.leg.fromStops({
+    id: "leg_a",
+    from: baseTrip.stops[0],
+    to: baseTrip.stops[1],
+    polyline: "polyline_a",
+    distance_m: 1500,
+    duration_s: 420,
+  });
+
+  const legB = modules.leg.fromStops({
+    id: "leg_b",
+    from: baseTrip.stops[1],
+    to: baseTrip.stops[2],
+    polyline: "polyline_b",
+    distance_m: 2300,
+    duration_s: 540,
+  });
+
+  const plannedTrip = modules.trip.attachRoutePlan(baseTrip, [legA, legB]);
+  const trackedTrip = modules.trip.updateRouteTrack(plannedTrip, 1900, 700);
+
+  assert.equal(plannedTrip.route_plan?.legs.length, 2);
+  assert.equal(plannedTrip.route_plan?.total_distance_m, 3800);
+  assert.equal(plannedTrip.route_plan?.total_duration_s, 960);
+  assert.equal(trackedTrip.route_track?.distance_done_m, 1900);
+  assert.equal(trackedTrip.route_track?.distance_remaining_m, 1900);
+  assert.equal(trackedTrip.route_track?.eta_s, 700);
+  assert.equal(trackedTrip.route_track?.progress_pct, 50);
+});

--- a/TNS/tests/unit/trip-module.unit.test.ts
+++ b/TNS/tests/unit/trip-module.unit.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createDomainModules } from "../../services/api/src/modules/index.js";
+
+test("TripModule normaliza ordem de stops e anexa route_plan", () => {
+  const modules = createDomainModules();
+
+  const trip = modules.trip.create({
+    id: "trip_1",
+    tenant_id: "tenant_1",
+    vehicle_id: "vehicle_1",
+    driver_id: "driver_1",
+    status: "planned",
+    stops: [
+      {
+        id: "stop_b",
+        order: 2,
+        name: "Destino",
+        address: "Rua B",
+        location: { lat: -23.56, lng: -46.64 },
+      },
+      {
+        id: "stop_a",
+        order: 1,
+        name: "Origem",
+        address: "Rua A",
+        location: { lat: -23.55, lng: -46.63 },
+      },
+    ],
+  });
+
+  const leg = modules.leg.fromStops({
+    id: "leg_1",
+    from: trip.stops[0],
+    to: trip.stops[1],
+    polyline: "abc",
+    distance_m: 2500,
+    duration_s: 600,
+  });
+
+  const withPlan = modules.trip.attachRoutePlan(trip, [leg]);
+
+  assert.equal(withPlan.stops[0]?.order, 0);
+  assert.equal(withPlan.stops[1]?.order, 1);
+  assert.equal(withPlan.route_plan?.total_distance_m, 2500);
+  assert.equal(withPlan.route_plan?.total_duration_s, 600);
+});

--- a/docs/error-log.md
+++ b/docs/error-log.md
@@ -109,3 +109,10 @@ Este arquivo registra erros relevantes, causa raiz e correcao aplicada.
 - Correcao aplicada: Adicionado filtro de comentario generico e mapeamento de badge `P0..P3` para severidade real.
 - Prevencao/acao futura: Manter smoke com finding real e revisar parser sempre que formato do comentario do bot mudar.
 - Referencias (comando/arquivo): issue `#8`, `.github/workflows/codex-findings-to-issues.yml`, `docs/codex-review-issues.md`.
+
+## 2026-03-03 - Typecheck falhou no S2-001 por caminho relativo incorreto
+- Sintoma: `corepack pnpm --dir TNS verify` falhou em `services/api` com `TS2307 Cannot find module .../packages/contracts/src/trip.js`.
+- Causa raiz: Imports nos novos módulos de domínio subiram 4 níveis em vez de 5 a partir de `services/api/src/modules/**`.
+- Correcao aplicada: Ajuste dos imports para `../../../../../packages/contracts/src/trip.js`.
+- Prevencao/acao futura: Validar caminho relativo com `tsc --noEmit` imediatamente após criar estrutura de pastas profundas.
+- Referencias (comando/arquivo): `TNS/services/api/src/modules/*/*.ts`, `corepack pnpm --dir TNS verify`.

--- a/docs/plan-change-log.md
+++ b/docs/plan-change-log.md
@@ -124,3 +124,11 @@ Este arquivo registra mudancas de plano e o motivo de cada mudanca.
 - Motivo da mudanca: Melhorar precisao da catalogacao e diminuir backlog falso-positivo.
 - Impacto no backlog/sprint: Issues criadas ficam mais acionaveis, com rotulo de severidade mais fiel.
 - Referencias (arquivos/PR/issue): `.github/workflows/codex-findings-to-issues.yml`, `docs/codex-review-issues.md`, issues `#7` e `#8`.
+
+## 2026-03-03 - Inicio de execucao da Sprint 2 pelo item S2-001
+- Contexto: Loop de operacao/review do repositorio estabilizado em `main`.
+- Decisao anterior: Prioridade em governanca de PR/review/catalogacao.
+- Decisao nova: Retomar backlog de produto com implementacao de `S2-001` (modulos de dominio Trip/Stop/Leg/RoutePlan/RouteTrack no `services/api`).
+- Motivo da mudanca: Avancar entrega funcional da Sprint 2 apos consolidacao de tooling.
+- Impacto no backlog/sprint: Base de dominio pronta para endpoints de `trips` (S2-007 em diante), com testes unit/integration cobrindo fluxo de modulo.
+- Referencias (arquivos/PR/issue): `TNS/services/api/src/modules/**`, `TNS/tests/unit/trip-module.unit.test.ts`, `TNS/tests/integration/api-domain-modules.integration.test.ts`.


### PR DESCRIPTION
## Summary
- Implementa `S2-001` com módulos de domínio no `services/api`:
  - `TripModule`
  - `StopModule`
  - `LegModule`
  - `RoutePlanModule`
  - `RouteTrackModule`
- Adiciona `createDomainModules` e endpoint operacional `/ops/domain-modules`.
- Adiciona testes `unit` e `integration` do fluxo de domínio.
- Atualiza `Codex-TNS.md` com status de execução do `S2-001`.
- Registra mudança de plano e erro/correção nos logs centrais.

## Scope
- [x] API contract/schema changed
- [ ] Database migration included (if schema changed)
- [ ] Multi-tenant scope validated (`tenant_id`)
- [x] Observability updated (logs/metrics)

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual validation executed (describe below)
- [ ] Se houve finding do Codex, catalogado em issue (`@codex create-issues`)

Manual validation notes:
- `corepack pnpm --dir TNS verify` green.

## Security Checklist
- [x] External input validated (DTO/schema + limits)
- [x] AuthZ checked on all affected endpoints
- [x] Sensitive data not logged
- [x] Abuse protection reviewed (rate limit/backoff)
- [x] New dependencies justified

## Risk and Rollback
- Risk level: `Low`
- Rollback plan:
  - Reverter este PR para voltar ao estado pré-S2-001.