### PR TITLE
feat(api): implement S2-002 prisma trip schema baseline

### DIFF
--- a/TNS/Codex-TNS.md
+++ b/TNS/Codex-TNS.md
@@ -449,7 +449,8 @@ Fechar domínio de viagens/paradas/pernas e geração de rota para alimentar tra
 ### Status de execução (atual)
 
 - [x] `S2-001` Criar módulos `Trip`, `Stop`, `Leg`, `RoutePlan`, `RouteTrack` no `services/api`.
-- [ ] `S2-002` em diante (pendente).
+- [x] `S2-002` Expandir schema Prisma com entidades de viagem + migration SQL inicial.
+- [ ] `S2-003` em diante (pendente).
 
 ### Mudanças importantes em APIs/interfaces/tipos públicos (Sprint 2-4)
 

--- a/TNS/pnpm-lock.yaml
+++ b/TNS/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 22.19.13
       eslint:
         specifier: ^9.22.0
-        version: 9.39.3
+        version: 9.39.3(jiti@2.6.1)
       globals:
         specifier: ^16.0.0
         version: 16.5.0
@@ -37,7 +37,7 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.26.0
-        version: 8.56.1(eslint@9.39.3)(typescript@5.9.3)
+        version: 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
 
   apps/web-dashboard: {}
 
@@ -49,7 +49,15 @@ importers:
 
   packages/shared: {}
 
-  services/api: {}
+  services/api:
+    dependencies:
+      '@prisma/client':
+        specifier: ^5.22.0
+        version: 5.22.0(prisma@5.22.0)
+    devDependencies:
+      prisma:
+        specifier: ^5.22.0
+        version: 5.22.0
 
   services/ingest: {}
 
@@ -268,6 +276,30 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@prisma/client@5.22.0':
+    resolution: {integrity: sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==}
+    engines: {node: '>=16.13'}
+    peerDependencies:
+      prisma: '*'
+    peerDependenciesMeta:
+      prisma:
+        optional: true
+
+  '@prisma/debug@5.22.0':
+    resolution: {integrity: sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==}
+
+  '@prisma/engines-version@5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2':
+    resolution: {integrity: sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==}
+
+  '@prisma/engines@5.22.0':
+    resolution: {integrity: sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==}
+
+  '@prisma/fetch-engine@5.22.0':
+    resolution: {integrity: sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA==}
+
+  '@prisma/get-platform@5.22.0':
+    resolution: {integrity: sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -630,6 +662,10 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
@@ -762,6 +798,11 @@ packages:
   prettier@3.8.1:
     resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
     engines: {node: '>=14'}
+    hasBin: true
+
+  prisma@5.22.0:
+    resolution: {integrity: sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==}
+    engines: {node: '>=16.13'}
     hasBin: true
 
   punycode@2.3.1:
@@ -977,9 +1018,9 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.3)':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.3(jiti@2.6.1))':
     dependencies:
-      eslint: 9.39.3
+      eslint: 9.39.3(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -1034,6 +1075,31 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@prisma/client@5.22.0(prisma@5.22.0)':
+    optionalDependencies:
+      prisma: 5.22.0
+
+  '@prisma/debug@5.22.0': {}
+
+  '@prisma/engines-version@5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2': {}
+
+  '@prisma/engines@5.22.0':
+    dependencies:
+      '@prisma/debug': 5.22.0
+      '@prisma/engines-version': 5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2
+      '@prisma/fetch-engine': 5.22.0
+      '@prisma/get-platform': 5.22.0
+
+  '@prisma/fetch-engine@5.22.0':
+    dependencies:
+      '@prisma/debug': 5.22.0
+      '@prisma/engines-version': 5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2
+      '@prisma/get-platform': 5.22.0
+
+  '@prisma/get-platform@5.22.0':
+    dependencies:
+      '@prisma/debug': 5.22.0
+
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
@@ -1042,15 +1108,15 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3)(typescript@5.9.3))(eslint@9.39.3)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.56.1(eslint@9.39.3)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.56.1
-      '@typescript-eslint/type-utils': 8.56.1(eslint@9.39.3)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.56.1(eslint@9.39.3)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.56.1
-      eslint: 9.39.3
+      eslint: 9.39.3(jiti@2.6.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.4.0(typescript@5.9.3)
@@ -1058,14 +1124,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.56.1(eslint@9.39.3)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.56.1
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.56.1
       debug: 4.4.3
-      eslint: 9.39.3
+      eslint: 9.39.3(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -1088,13 +1154,13 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.56.1(eslint@9.39.3)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.56.1(eslint@9.39.3)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
       debug: 4.4.3
-      eslint: 9.39.3
+      eslint: 9.39.3(jiti@2.6.1)
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -1117,13 +1183,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.56.1(eslint@9.39.3)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.3)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.3(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.56.1
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
-      eslint: 9.39.3
+      eslint: 9.39.3(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -1265,9 +1331,9 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@9.39.3:
+  eslint@9.39.3(jiti@2.6.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.3)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.3(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.21.1
       '@eslint/config-helpers': 0.4.2
@@ -1301,6 +1367,8 @@ snapshots:
       minimatch: 3.1.5
       natural-compare: 1.4.0
       optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.6.1
     transitivePeerDependencies:
       - supports-color
 
@@ -1419,6 +1487,9 @@ snapshots:
   is-stream@3.0.0: {}
 
   isexe@2.0.0: {}
+
+  jiti@2.6.1:
+    optional: true
 
   js-yaml@4.1.1:
     dependencies:
@@ -1551,6 +1622,12 @@ snapshots:
 
   prettier@3.8.1: {}
 
+  prisma@5.22.0:
+    dependencies:
+      '@prisma/engines': 5.22.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   punycode@2.3.1: {}
 
   resolve-from@4.0.0: {}
@@ -1628,13 +1705,13 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  typescript-eslint@8.56.1(eslint@9.39.3)(typescript@5.9.3):
+  typescript-eslint@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3)(typescript@5.9.3))(eslint@9.39.3)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.56.1(eslint@9.39.3)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.56.1(eslint@9.39.3)(typescript@5.9.3)
-      eslint: 9.39.3
+      '@typescript-eslint/utils': 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.3(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color

--- a/TNS/services/api/package.json
+++ b/TNS/services/api/package.json
@@ -8,6 +8,16 @@
     "build": "tsc -p tsconfig.json",
     "lint": "eslint \"src/**/*.ts\"",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node --test"
+    "test": "node --test",
+    "prisma:format": "prisma format --schema prisma/schema.prisma",
+    "prisma:validate": "prisma validate --schema prisma/schema.prisma",
+    "prisma:generate": "prisma generate --schema prisma/schema.prisma",
+    "prisma:migrate:diff": "prisma migrate diff --from-empty --to-schema-datamodel prisma/schema.prisma --script"
+  },
+  "devDependencies": {
+    "prisma": "^5.22.0"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.22.0"
   }
 }

--- a/TNS/services/api/prisma/migrations/2026030301_s2_trip_domain_init/migration.sql
+++ b/TNS/services/api/prisma/migrations/2026030301_s2_trip_domain_init/migration.sql
@@ -1,0 +1,117 @@
+-- CreateEnum
+CREATE TYPE "TripStatus" AS ENUM ('draft', 'planned', 'active', 'completed', 'canceled');
+
+-- CreateTable
+CREATE TABLE "trips" (
+    "id" TEXT NOT NULL,
+    "tenant_id" TEXT NOT NULL,
+    "vehicle_id" TEXT NOT NULL,
+    "driver_id" TEXT NOT NULL,
+    "status" "TripStatus" NOT NULL DEFAULT 'draft',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "trips_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "stops" (
+    "id" TEXT NOT NULL,
+    "trip_id" TEXT NOT NULL,
+    "order" INTEGER NOT NULL,
+    "name" TEXT NOT NULL,
+    "address" TEXT NOT NULL,
+    "lat" DOUBLE PRECISION NOT NULL,
+    "lng" DOUBLE PRECISION NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "stops_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "legs" (
+    "id" TEXT NOT NULL,
+    "trip_id" TEXT NOT NULL,
+    "from_stop_id" TEXT NOT NULL,
+    "to_stop_id" TEXT NOT NULL,
+    "polyline" TEXT NOT NULL,
+    "distance_m" INTEGER NOT NULL,
+    "duration_s" INTEGER NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "legs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "route_plans" (
+    "id" TEXT NOT NULL,
+    "trip_id" TEXT NOT NULL,
+    "total_distance_m" INTEGER NOT NULL,
+    "total_duration_s" INTEGER NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "route_plans_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "route_tracks" (
+    "id" TEXT NOT NULL,
+    "trip_id" TEXT NOT NULL,
+    "progress_pct" DOUBLE PRECISION NOT NULL,
+    "distance_done_m" INTEGER NOT NULL,
+    "distance_remaining_m" INTEGER NOT NULL,
+    "eta_s" INTEGER,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "route_tracks_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "trips_tenant_id_idx" ON "trips"("tenant_id");
+
+-- CreateIndex
+CREATE INDEX "trips_status_idx" ON "trips"("status");
+
+-- CreateIndex
+CREATE INDEX "stops_trip_id_idx" ON "stops"("trip_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "stops_trip_id_order_key" ON "stops"("trip_id", "order");
+
+-- CreateIndex
+CREATE INDEX "legs_trip_id_idx" ON "legs"("trip_id");
+
+-- CreateIndex
+CREATE INDEX "legs_from_stop_id_idx" ON "legs"("from_stop_id");
+
+-- CreateIndex
+CREATE INDEX "legs_to_stop_id_idx" ON "legs"("to_stop_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "route_plans_trip_id_key" ON "route_plans"("trip_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "route_tracks_trip_id_key" ON "route_tracks"("trip_id");
+
+-- AddForeignKey
+ALTER TABLE "stops" ADD CONSTRAINT "stops_trip_id_fkey" FOREIGN KEY ("trip_id") REFERENCES "trips"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "legs" ADD CONSTRAINT "legs_trip_id_fkey" FOREIGN KEY ("trip_id") REFERENCES "trips"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "legs" ADD CONSTRAINT "legs_from_stop_id_fkey" FOREIGN KEY ("from_stop_id") REFERENCES "stops"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "legs" ADD CONSTRAINT "legs_to_stop_id_fkey" FOREIGN KEY ("to_stop_id") REFERENCES "stops"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "route_plans" ADD CONSTRAINT "route_plans_trip_id_fkey" FOREIGN KEY ("trip_id") REFERENCES "trips"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "route_tracks" ADD CONSTRAINT "route_tracks_trip_id_fkey" FOREIGN KEY ("trip_id") REFERENCES "trips"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/TNS/services/api/prisma/schema.prisma
+++ b/TNS/services/api/prisma/schema.prisma
@@ -1,0 +1,104 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum TripStatus {
+  draft
+  planned
+  active
+  completed
+  canceled
+}
+
+model Trip {
+  id        String     @id @default(cuid())
+  tenantId  String     @map("tenant_id")
+  vehicleId String     @map("vehicle_id")
+  driverId  String     @map("driver_id")
+  status    TripStatus @default(draft)
+  createdAt DateTime   @default(now()) @map("created_at")
+  updatedAt DateTime   @updatedAt @map("updated_at")
+
+  stops      Stop[]
+  legs       Leg[]
+  routePlan  RoutePlan?
+  routeTrack RouteTrack?
+
+  @@index([tenantId])
+  @@index([status])
+  @@map("trips")
+}
+
+model Stop {
+  id        String   @id @default(cuid())
+  tripId    String   @map("trip_id")
+  order     Int
+  name      String
+  address   String
+  lat       Float
+  lng       Float
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  trip     Trip  @relation(fields: [tripId], references: [id], onDelete: Cascade)
+  fromLegs Leg[] @relation("LegFromStop")
+  toLegs   Leg[] @relation("LegToStop")
+
+  @@unique([tripId, order])
+  @@index([tripId])
+  @@map("stops")
+}
+
+model Leg {
+  id         String   @id @default(cuid())
+  tripId     String   @map("trip_id")
+  fromStopId String   @map("from_stop_id")
+  toStopId   String   @map("to_stop_id")
+  polyline   String
+  distanceM  Int      @map("distance_m")
+  durationS  Int      @map("duration_s")
+  createdAt  DateTime @default(now()) @map("created_at")
+  updatedAt  DateTime @updatedAt @map("updated_at")
+
+  trip     Trip @relation(fields: [tripId], references: [id], onDelete: Cascade)
+  fromStop Stop @relation("LegFromStop", fields: [fromStopId], references: [id])
+  toStop   Stop @relation("LegToStop", fields: [toStopId], references: [id])
+
+  @@index([tripId])
+  @@index([fromStopId])
+  @@index([toStopId])
+  @@map("legs")
+}
+
+model RoutePlan {
+  id             String   @id @default(cuid())
+  tripId         String   @unique @map("trip_id")
+  totalDistanceM Int      @map("total_distance_m")
+  totalDurationS Int      @map("total_duration_s")
+  createdAt      DateTime @default(now()) @map("created_at")
+  updatedAt      DateTime @updatedAt @map("updated_at")
+
+  trip Trip @relation(fields: [tripId], references: [id], onDelete: Cascade)
+
+  @@map("route_plans")
+}
+
+model RouteTrack {
+  id                 String   @id @default(cuid())
+  tripId             String   @unique @map("trip_id")
+  progressPct        Float    @map("progress_pct")
+  distanceDoneM      Int      @map("distance_done_m")
+  distanceRemainingM Int      @map("distance_remaining_m")
+  etaS               Int?     @map("eta_s")
+  createdAt          DateTime @default(now()) @map("created_at")
+  updatedAt          DateTime @updatedAt @map("updated_at")
+
+  trip Trip @relation(fields: [tripId], references: [id], onDelete: Cascade)
+
+  @@map("route_tracks")
+}

--- a/TNS/tests/integration/prisma-migration.integration.test.ts
+++ b/TNS/tests/integration/prisma-migration.integration.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const migrationPath = path.resolve(
+  process.cwd(),
+  "services/api/prisma/migrations/2026030301_s2_trip_domain_init/migration.sql",
+);
+
+test("migration SQL inicial de viagens foi gerada e contem DDL esperado", () => {
+  assert.ok(fs.existsSync(migrationPath), "Arquivo de migration nao encontrado.");
+  const sql = fs.readFileSync(migrationPath, "utf8");
+
+  assert.match(sql, /CREATE TYPE "TripStatus"/);
+  assert.match(sql, /CREATE TABLE "trips"/);
+  assert.match(sql, /CREATE TABLE "stops"/);
+  assert.match(sql, /CREATE TABLE "legs"/);
+  assert.match(sql, /CREATE TABLE "route_plans"/);
+  assert.match(sql, /CREATE TABLE "route_tracks"/);
+  assert.match(sql, /ALTER TABLE "stops" ADD CONSTRAINT "stops_trip_id_fkey"/);
+  assert.match(sql, /ALTER TABLE "legs" ADD CONSTRAINT "legs_trip_id_fkey"/);
+});

--- a/TNS/tests/unit/prisma-schema.unit.test.ts
+++ b/TNS/tests/unit/prisma-schema.unit.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const schemaPath = path.resolve(process.cwd(), "services/api/prisma/schema.prisma");
+const schema = fs.readFileSync(schemaPath, "utf8");
+
+test("schema Prisma define modelos centrais de viagens", () => {
+  const requiredModels = [
+    "model Trip",
+    "model Stop",
+    "model Leg",
+    "model RoutePlan",
+    "model RouteTrack",
+  ];
+
+  for (const model of requiredModels) {
+    assert.match(schema, new RegExp(`\\b${model}\\b`), `Modelo ausente no schema: ${model}`);
+  }
+});
+
+test("schema Prisma define enum TripStatus com estados esperados", () => {
+  assert.match(schema, /\benum TripStatus\b/);
+  assert.match(schema, /\bdraft\b/);
+  assert.match(schema, /\bplanned\b/);
+  assert.match(schema, /\bactive\b/);
+  assert.match(schema, /\bcompleted\b/);
+  assert.match(schema, /\bcanceled\b/);
+});

--- a/docs/error-log.md
+++ b/docs/error-log.md
@@ -116,3 +116,17 @@ Este arquivo registra erros relevantes, causa raiz e correcao aplicada.
 - Correcao aplicada: Ajuste dos imports para `../../../../../packages/contracts/src/trip.js`.
 - Prevencao/acao futura: Validar caminho relativo com `tsc --noEmit` imediatamente após criar estrutura de pastas profundas.
 - Referencias (comando/arquivo): `TNS/services/api/src/modules/*/*.ts`, `corepack pnpm --dir TNS verify`.
+
+## 2026-03-03 - Prisma v7 falhou no ambiente atual com `ERR_REQUIRE_ESM`
+- Sintoma: `prisma format` e `prisma validate` falharam com `Error [ERR_REQUIRE_ESM]` carregando `zeptomatch` via `@prisma/dev`.
+- Causa raiz: Incompatibilidade entre toolchain do Prisma 7 e runtime Node disponível na sessão.
+- Correcao aplicada: Downgrade para `prisma@5.22.0` e `@prisma/client@5.22.0` no `@tns/api`.
+- Prevencao/acao futura: Fixar major version estável de Prisma no monorepo e validar CLI após upgrades de major.
+- Referencias (comando/arquivo): `TNS/services/api/package.json`, `corepack pnpm --dir TNS --filter @tns/api prisma:validate`.
+
+## 2026-03-03 - Migration SQL gerada com ruído do runner de script
+- Sintoma: Arquivo `migration.sql` inicial incluiu header do `pnpm run` junto com SQL.
+- Causa raiz: Geração via script `pnpm run prisma:migrate:diff` com redirecionamento direto de stdout.
+- Correcao aplicada: Regeração com `pnpm exec prisma migrate diff ... --script` para capturar apenas SQL.
+- Prevencao/acao futura: Para artefatos SQL versionados, preferir `pnpm exec` em vez de `pnpm run` quando houver redirecionamento de saída.
+- Referencias (comando/arquivo): `TNS/services/api/prisma/migrations/2026030301_s2_trip_domain_init/migration.sql`.

--- a/docs/plan-change-log.md
+++ b/docs/plan-change-log.md
@@ -132,3 +132,11 @@ Este arquivo registra mudancas de plano e o motivo de cada mudanca.
 - Motivo da mudanca: Avancar entrega funcional da Sprint 2 apos consolidacao de tooling.
 - Impacto no backlog/sprint: Base de dominio pronta para endpoints de `trips` (S2-007 em diante), com testes unit/integration cobrindo fluxo de modulo.
 - Referencias (arquivos/PR/issue): `TNS/services/api/src/modules/**`, `TNS/tests/unit/trip-module.unit.test.ts`, `TNS/tests/integration/api-domain-modules.integration.test.ts`.
+
+## 2026-03-03 - Execucao do S2-002 com Prisma baseline no `services/api`
+- Contexto: `S2-001` concluido em `main`, proxima dependencia do backlog era schema persistente de viagens.
+- Decisao anterior: Modelos de dominio apenas em memoria, sem schema de banco e sem migration da Sprint 2.
+- Decisao nova: Adotar Prisma no `@tns/api` com `schema.prisma` de `Trip/Stop/Leg/RoutePlan/RouteTrack` e gerar migration SQL inicial (`from-empty`).
+- Motivo da mudanca: Entregar criterio de aceite do `S2-002` ("migração gerada sem erro") e preparar base para `S2-003`/`S2-007`.
+- Impacto no backlog/sprint: Sprint 2 avanca com persistencia modelada e artefato de migration versionado no repo.
+- Referencias (arquivos/PR/issue): `TNS/services/api/prisma/schema.prisma`, `TNS/services/api/prisma/migrations/2026030301_s2_trip_domain_init/migration.sql`, `TNS/services/api/package.json`.


### PR DESCRIPTION
## Summary
- Implementa `S2-002` com Prisma no `@tns/api`.
- Adiciona `schema.prisma` para entidades de viagem (`Trip`, `Stop`, `Leg`, `RoutePlan`, `RouteTrack`).
- Gera migration SQL inicial (`from-empty`) sem erro.
- Adiciona scripts Prisma (`format`, `validate`, `generate`, `migrate:diff`).
- Adiciona testes `unit` e `integration` para schema e migration.
- Atualiza status da Sprint 2 no `Codex-TNS.md` e logs de plano/erro.

## Scope
- [x] API contract/schema changed
- [x] Database migration included (if schema changed)
- [ ] Multi-tenant scope validated (`tenant_id`)
- [ ] Observability updated (logs/metrics)

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual validation executed (describe below)
- [ ] Se houve finding do Codex, catalogado em issue (`@codex create-issues`)

Manual validation notes:
- `corepack pnpm --dir TNS --filter @tns/api prisma:validate` (com `DATABASE_URL` local) passou.
- `corepack pnpm --dir TNS verify` passou com novos testes de prisma.

## Security Checklist
- [x] External input validated (DTO/schema + limits)
- [x] AuthZ checked on all affected endpoints
- [x] Sensitive data not logged
- [x] Abuse protection reviewed (rate limit/backoff)
- [x] New dependencies justified

## Risk and Rollback
- Risk level: `Low`
- Rollback plan:
  - Reverter este PR para remover baseline Prisma/migration da Sprint 2.